### PR TITLE
Fix Correct loading of categories in the main screen and refactory  default the controller is shared generating conflicts.

### DIFF
--- a/lib/Models/HomeModel.dart
+++ b/lib/Models/HomeModel.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+class HomeModel {
+  String title;
+  List playlists;
+
+  HomeModel({
+    required this.title,
+    required this.playlists,
+  });
+
+  String get getTitle => title;
+  List get getPlaylist => playlists;
+
+  set setTitle(String title) => this.title = title;
+  set setPlaylist(List playlists) => this.playlists = playlists;
+
+  HomeModel copyWith({
+    String? title,
+    List? playlists,
+  }) {
+    return HomeModel(
+      title: title ?? this.title,
+      playlists: playlists ?? this.playlists,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'title': title,
+      'playlist': playlists,
+    };
+  }
+
+  factory HomeModel.fromMap(Map<String, dynamic> map) {
+    return HomeModel(
+      title: map['title'] as String,
+      playlists: List.from(
+        (map['playlist'] as List),
+      ),
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  factory HomeModel.fromJson(String source) =>
+      HomeModel.fromMap(json.decode(source) as Map<String, dynamic>);
+
+  @override
+  String toString() => 'HomeModel(title: $title, playlist: $playlists)';
+
+  @override
+  bool operator ==(covariant HomeModel other) {
+    if (identical(this, other)) return true;
+
+    return other.title == title && listEquals(other.playlists, playlists);
+  }
+
+  @override
+  int get hashCode => title.hashCode ^ playlists.hashCode;
+}

--- a/lib/data/home1.dart
+++ b/lib/data/home1.dart
@@ -4,6 +4,8 @@ import 'dart:developer';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:http/http.dart';
 
+import '../Models/HomeModel.dart';
+
 Box box = Hive.box('settings');
 
 class HomeApi {
@@ -82,51 +84,72 @@ class HomeApi {
         return element['itemSectionRenderer']['contents'][0]['shelfRenderer'];
       }).toList();
 
-      final List finalResult = shelfRenderer.map((element) {
-        if (element['title']['runs'][0]['text'].trim() !=
-            'Highlights from Global Citizen Live') {
-          return {
-            'title': element['title']['runs'][0]['text'],
-            'playlists': element['title']['runs'][0]['text'].trim() ==
-                        'Charts' ||
-                    element['title']['runs'][0]['text'].trim() == 'Classements'
-                ? formatChartItems(
-                    element['content']['horizontalListRenderer']['items']
-                        as List,
-                  )
-                : element['title']['runs'][0]['text']
-                            .toString()
-                            .contains('Music Videos') ||
-                        element['title']['runs'][0]['text']
-                            .toString()
-                            .contains('Nouveaux clips') ||
-                        element['title']['runs'][0]['text']
-                            .toString()
-                            .contains('En Musique Avec Moi') ||
-                        element['title']['runs'][0]['text']
-                            .toString()
-                            .contains('Performances Uniques')
-                    ? formatVideoItems(
-                        element['content']['horizontalListRenderer']['items']
-                            as List,
-                      )
-                    : formatItems(
-                        element['content']['horizontalListRenderer']['items']
-                            as List,
-                      ),
-          };
-        } else {
-          return null;
-        }
-      }).toList();
+      var finalResult = _finalResult(shelfRenderer);
 
       final List finalHeadResult = formatHeadItems(headResult);
-      finalResult.removeWhere((element) => element == null);
+      finalResult.removeWhere((element) => element.playlists.isEmpty);
 
       return {'body': finalResult, 'head': finalHeadResult};
     } catch (e) {
       log('Error in getMusicHome: $e');
       return {};
+    }
+  }
+
+  /*
+   * Gets the final list of playlists sorted by the name of each iterated item,
+   * this list contains the url of the video and playlists of each horizontal 
+   * column reflected in Youtube.
+   */
+  List<HomeModel> _finalResult(List shelfRenderer) {
+    var data = <HomeModel>[];
+
+    try {
+      for (var element in shelfRenderer) {
+        HomeModel homeModel = HomeModel(title: "", playlists: []);
+
+        if (element['title']['runs'][0]['text'].trim() !=
+            'Highlights from Global Citizen Live') {
+          homeModel.title = element['title']['runs'][0]['text'].toString();
+
+          if (element['content']['horizontalListRenderer']['items'][0]
+                      ['gridPlaylistRenderer'] !=
+                  null &&
+              element['content']['horizontalListRenderer']['items'][0]
+                          ['gridPlaylistRenderer']['shortBylineText']['runs'][0]
+                      ['text']
+                  .toString()
+                  .trim()
+                  .toLowerCase()
+                  .contains('chart')) {
+            //Lists YouTube Music Global Charts.
+            homeModel.playlists = formatChartItems(
+                element['content']['horizontalListRenderer']['items']);
+            data.add(homeModel);
+          }
+
+          if (element['content']['horizontalListRenderer']['items'][0]
+                  ['gridVideoRenderer'] !=
+              null) {
+            //The video playlist is added.
+            homeModel.playlists = formatVideoItems(
+                element['content']['horizontalListRenderer']['items']);
+            data.add(homeModel);
+          }
+
+          if (element['content']['horizontalListRenderer']['items'][0]
+                  ['compactStationRenderer'] !=
+              null) {
+            //Lists other than videos or video playlists are added.
+            homeModel.playlists = formatItems(
+                element['content']['horizontalListRenderer']['items']);
+            data.add(homeModel);
+          }
+        }
+      }
+      return data;
+    } catch (e) {
+      return <HomeModel>[];
     }
   }
 

--- a/lib/screens/HomeScreen.dart
+++ b/lib/screens/HomeScreen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:vibe_music/Models/Artist.dart';
+import 'package:vibe_music/Models/HomeModel.dart';
 import 'package:vibe_music/Models/Thumbnail.dart';
 import 'package:vibe_music/Models/Track.dart';
 import 'package:vibe_music/data/home1.dart';
@@ -36,7 +37,7 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen>
     with AutomaticKeepAliveClientMixin<HomeScreen> {
   List? head = [];
-  List? body = [];
+  List<HomeModel> body = [];
   List recommendations = [];
   bool isLoading = true;
   PageController songsController = PageController(
@@ -527,9 +528,8 @@ class _HomeScreenState extends State<HomeScreen>
                                           ),
                                         if (body != null && body!.isNotEmpty)
                                           ...body!.map((item) {
-                                            String title = item['title'];
-                                            List content =
-                                                item['playlists'] as List;
+                                            String title = item.title;
+                                            List content = item.playlists;
                                             bool areSongs = content.isNotEmpty
                                                 ? content.first['videoId'] !=
                                                     null

--- a/lib/screens/HomeScreen.dart
+++ b/lib/screens/HomeScreen.dart
@@ -40,12 +40,6 @@ class _HomeScreenState extends State<HomeScreen>
   List<HomeModel> body = [];
   List recommendations = [];
   bool isLoading = true;
-  PageController songsController = PageController(
-    viewportFraction: 0.9,
-  );
-  PageController recommendationsController = PageController(
-    viewportFraction: 0.9,
-  );
   @override
   void initState() {
     super.initState();
@@ -68,12 +62,6 @@ class _HomeScreenState extends State<HomeScreen>
       body = home['body'];
       recommendations = recommend;
       isLoading = false;
-      if (recommendationsController.hasClients) {
-        recommendationsController.jumpTo(0);
-      }
-      if (songsController.hasClients) {
-        songsController.jumpTo(0);
-      }
     });
   }
 
@@ -433,8 +421,10 @@ class _HomeScreenState extends State<HomeScreen>
                                                 ),
                                               ),
                                               ExpandablePageView(
-                                                controller:
-                                                    recommendationsController,
+                                                controller: PageController(
+                                                  initialPage: 0,
+                                                  viewportFraction: 0.9,
+                                                ),
                                                 padEnds: false,
                                                 children: [
                                                   Column(
@@ -572,7 +562,11 @@ class _HomeScreenState extends State<HomeScreen>
                                                         if (areSongs)
                                                           ExpandablePageView(
                                                             controller:
-                                                                songsController,
+                                                                PageController(
+                                                              initialPage: 0,
+                                                              viewportFraction:
+                                                                  0.9,
+                                                            ),
                                                             padEnds: false,
                                                             children: [
                                                               Column(


### PR DESCRIPTION
### **Correct loading of categories in the main screen**

> Video Category: 

![image](https://user-images.githubusercontent.com/17989537/220796831-65dafdc5-a282-46ab-a6d9-bd95ba0b4aa6.png)
 

> Charts / Global Music

![image](https://user-images.githubusercontent.com/17989537/220797094-6b72f589-d0a5-4b6f-bdb1-8b289085ea76.png)

### **Refactory  default the controller is shared generating conflicts**

When having two or more PageController in the same page the second one in being generated enters in conflict what generates the error of _(The page property cannot be read when multiple PageViews are attached to the same PageController. package:flutter/src/widgets/page_view.dart': Failed assertion: line 101 pos 7: 'positions.length == 1)_ . to solve it it is necessary to create inside the widget to de-centralize it.