### PR TITLE
Bugfix/screen_sleep_during_lyrics_edge_condition

### DIFF
--- a/lib/screens/main_screen/lyrics_box.dart
+++ b/lib/screens/main_screen/lyrics_box.dart
@@ -53,6 +53,7 @@ class _LyricsBoxState extends State<LyricsBox> {
   }
 
   void _updateWakelock() {
+    if (!mounted) return;
     final isPlaying =
         GetIt.I<MediaPlayer>().buttonState.value == ButtonState.playing;
     if (isPlaying && _lyricsLoaded) {


### PR DESCRIPTION
Added a mounted check in _updateWakelock to avoid enabling the wakelock when edge conditions occur,
such as opening lyrics and quickly leaving the page.