### PR TITLE
Refactor autofetch functionality with listener and settings toggle

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -40,6 +40,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "Audio_And_Playback": MessageLookupByLibrary.simpleMessage(
       "Audio and Playback",
     ),
+    "Autofetch_Songs": MessageLookupByLibrary.simpleMessage(
+      "Autoplay Similar Songs",
+    ),
     "Backup": MessageLookupByLibrary.simpleMessage("Backup"),
     "Backup_And_Restore": MessageLookupByLibrary.simpleMessage(
       "Backup and Restore",

--- a/lib/generated/intl/messages_it.dart
+++ b/lib/generated/intl/messages_it.dart
@@ -44,6 +44,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "Audio_And_Playback": MessageLookupByLibrary.simpleMessage(
       "Audio e riproduzione",
     ),
+    "Autofetch_Songs": MessageLookupByLibrary.simpleMessage(
+      "Riproduci automaticamente brani simili",
+    ),
     "Backup": MessageLookupByLibrary.simpleMessage("Backup"),
     "Backup_And_Restore": MessageLookupByLibrary.simpleMessage(
       "Backup e ripristino",

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -307,6 +307,16 @@ class S {
     );
   }
 
+  /// `Autoplay Similar Songs`
+  String get Autofetch_Songs {
+    return Intl.message(
+      'Autoplay Similar Songs',
+      name: 'Autofetch_Songs',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Personalised Content`
   String get Personalised_Content {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -78,6 +78,8 @@
   "@Language": {},
   "Translate_Lyrics": "Translate Lyrics",
   "@Translate_Lyrics": {},
+  "Autofetch_Songs": "Autoplay Similar Songs",
+  "@Autofetch_Songs": {},
   "Personalised_Content": "Personalised Content",
   "@Personalised_Content": {},
   "Enter_Visitor_Id": "Enter Visitor Id",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -78,6 +78,8 @@
   "@Language": {},
   "Translate_Lyrics": "Traduci testi",
   "@Translate_Lyrics": {},
+  "Autofetch_Songs": "Riproduci automaticamente brani simili",
+  "@Autofetch_Songs": {},
   "Personalised_Content": "Contenuti personalizzati",
   "@Personalised_Content": {},
   "Enter_Visitor_Id": "Inserisci Visitor ID",

--- a/lib/screens/settings_screen/services/ytmusic.dart
+++ b/lib/screens/settings_screen/services/ytmusic.dart
@@ -87,12 +87,21 @@ class YtMusicScreen extends StatelessWidget {
                   return SettingSwitchTile(
                     title: S.of(context).Translate_Lyrics,
                     leading: Icon(Icons.translate_outlined),
-                    isLast: true,
+                    isLast: false,
                     value: item.get('TRANSLATE_LYRICS', defaultValue: false),
                     onChanged: (value) async {
                       await box.put('TRANSLATE_LYRICS', value);
                     },
                   );
+                },
+              ),
+              SettingSwitchTile(
+                title: S.of(context).Autofetch_Songs,
+                leading: Icon(Icons.autorenew_outlined),
+                isLast: true,
+                value: context.watch<SettingsManager>().autofetchSongs,
+                onChanged: (value) {
+                  context.read<SettingsManager>().autofetchSongs = value;
                 },
               ),
               GroupTitle(title: "Playback & download"),

--- a/lib/services/settings_manager.dart
+++ b/lib/services/settings_manager.dart
@@ -15,6 +15,7 @@ class SettingsManager extends ChangeNotifier {
   ];
   late Map<String, String> _location;
   late Map<String, String> _language;
+  bool _autofetchSongs = true;
   final List<AudioQuality> _audioQualities = [
     AudioQuality.high,
     AudioQuality.low
@@ -36,6 +37,7 @@ class SettingsManager extends ChangeNotifier {
   Map<String, String> get location => _location;
   List<Map<String, String>> get locations => _countries;
   Map<String, String> get language => _language;
+  bool get autofetchSongs => _autofetchSongs;
   List<Map<String, String>> get languages => _languages;
   List<AudioQuality> get audioQualities => _audioQualities;
   AudioQuality get streamingQuality => _streamingQuality;
@@ -58,6 +60,7 @@ class SettingsManager extends ChangeNotifier {
     _themeMode = _themeModes[_box.get('THEME_MODE', defaultValue: 0)];
     _language = _languages.firstWhere((language) =>
         language['value'] == _box.get('LANGUAGE', defaultValue: 'en-IN'));
+    _autofetchSongs = _box.get('AUTOFETCH_SONGS', defaultValue: true);
     _accentColor = _box.get('ACCENT_COLOR') != null
         ? Color(_box.get('ACCENT_COLOR'))
         : null;
@@ -97,6 +100,12 @@ class SettingsManager extends ChangeNotifier {
     _box.put('LANGUAGE', value['value']);
     _language = value;
     GetIt.I<YTMusic>().refreshContext();
+    notifyListeners();
+  }
+
+  set autofetchSongs(bool value) {
+    _box.put('AUTOFETCH_SONGS', value);
+    _autofetchSongs = value;
     notifyListeners();
   }
 


### PR DESCRIPTION
Fixes non-deterministic behavior in the autofetch feature and refactors its implementation.

Issues with the previous autoFetch songs behavior:
- Playing a single song and closing the player could make the mini player reappear later with a random playlist (due to the “autofetch” behavior at the end of a single song).
- Playing a new single song while a previous single song was playing would append the old queue to the new song.
- Autofetch did not trigger at the end of an album or playlist playback.

Changes in this PR:
- Removes old implementation in playSong that caused inconsistent behavior.
- Implements _listenToAutofetch() with a dedicated listener for clean, deterministic behavior.
- Feature is toggleable from YTMusic settings page.