### PR TITLE
fix: fixed version checking and double dialog

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,7 +57,6 @@ android {
         beta {
             dimension = "default"
             applicationIdSuffix = ".beta"
-            versionNameSuffix = "-beta"
         }
         production {
             dimension = "default"

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -96,9 +96,6 @@ class SettingsPage extends StatelessWidget {
                       title: S.of(context).Check_For_Update,
                       leading: const Icon(Icons.update_rounded),
                       onTap: () async {
-                        Modals.showCenterLoadingModal(
-                          context,
-                        );
                         await UpdateService.manualCheck(context);
                       },
                     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -459,14 +459,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4+6"
-  flutter_markdown:
-    dependency: "direct main"
-    description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.7+1"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -757,14 +749,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
-  markdown:
-    dependency: transitive
-    description:
-      name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.3.0"
   matcher:
     dependency: transitive
     description:


### PR DESCRIPTION
* Fixed version name in about page which used to show double beta.
* Fixed showing double dialogs when checking update manually.