### PR TITLE
Fix duplicated "Songs" playlist in Downloads after app update

### DIFF
--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -110,6 +110,12 @@ class DownloadManager {
           },
         };
         mapToUpdate[key.toString()] = song;
+      } else if (song["playlists"] is Map &&
+          (song["playlists"] as Map).keys.contains("songs")) {
+        // 2) RENAME OLD SONGS PLAYLIST
+        final pl = song["playlists"].remove("songs");
+        song["playlists"][songsPlaylistId] = pl;
+        mapToUpdate[key.toString()] = song;
       }
     }
     // 1) UPDATE DOWNLOADS


### PR DESCRIPTION
Resolved an issue where the "Songs" playlist was duplicated in Downloads after a software update due to a changed playlist ID (songsPlaylistId). Updated _cleanAndMigrateData to rename legacy playlist ID during migration.